### PR TITLE
Reenable build for OSX/Arm64

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+libblas:
+- 3.9 *netlib
+llvm_openmp:
+- '14'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/simple-dftd3-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11844&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/simple-dftd3-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 conda_forge_output_validation: true
-test_on_native_only: true
+test: native_and_emulated
 build_platform:
   osx_arm64: osx_64
   linux_aarch64: linux_64

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 
 set -ex
+
 mv $PREFIX/lib/pkgconfig/blas.pc $SRC_DIR
 
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then
+  MESON_ARGS=${MESON_ARGS:---prefix=${PREFIX} --libdir=lib}
+else
+  cat > pkgconfig.ini <<EOF
+[binaries]
+pkgconfig = '$BUILD_PREFIX/bin/pkg-config'
+EOF
+  MESON_ARGS="${MESON_ARGS:---prefix=${PREFIX} --libdir=lib} --cross-file pkgconfig.ini"
+fi
+
 meson setup _build \
-  ${MESON_ARGS:---prefix=${PREFIX} --libdir=lib} \
-  --buildtype=release \
-  -Dblas=custom -Dblas_libs=blas
+  ${MESON_ARGS} \
+  --buildtype=release -Dblas=custom \
+  -Dblas_libs=blas
 
 meson compile -C _build
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" != "1" ]]; then
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then
   meson test -C _build --no-rebuild --print-errorlogs
 fi
 meson install -C _build --no-rebuild
+
 mv $SRC_DIR/blas.pc $PREFIX/lib/pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
     - wrap.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
-  skip: true  # [osx and arm64]
 
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -32,7 +31,7 @@ requirements:
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
   host:
-    - libblas  # [unix]
+    - libblas
     - mctc-lib
     - toml-f
 


### PR DESCRIPTION
MNT: Re-rendered with conda-build 3.23.3, conda-smithy 3.22.1, and conda-forge-pinning 2023.01.04.13.03.46

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
